### PR TITLE
fix not working in node.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,75 @@
 # kysely-neon
 
-[Kysely](https://github.com/koskimas/kysely) adapter for [Neon](https://neon.tech/) serverless postgres.
-
-```bash
-npm i kysely-neon @neondatabase/serverless ws
-```
+[Kysely](https://github.com/koskimas/kysely) dialect for [Neon](https://neon.tech/) serverless postgres.
 
 > Created with help from [kysely-d1](https://github.com/aidenwallis/kysely-d1) and the [neon serverless binding](https://github.com/neondatabase/serverless)
 
+## Setup
+
+Edge runtime:
+
+```bash
+npm i kysely-neon kysely @neondatabase/serverless
+```
+
+Node.js:
+
+```bash
+npm i kysely-neon kysely @neondatabase/serverless ws
+```
+
 ## Usage
 
+Edge runtime:
+
 ```typescript
+import { GeneratedAlways, Kysely } from "kysely"
+import { NeonDialect } from "kysely-neon"
+
 interface Database {
   person: PersonTable
-  pet: PetTable
-  movie: MovieTable
+}
+
+interface PersonTable {
+  id: GeneratedAlways<number>
+  first_name: string
+  gender: "male" | "female" | "other"
 }
 
 const db = new Kysely<Database>({
   dialent: new NeonDialect({
     connectionString: process.env.DATABASE_URL,
+  }),
+})
+
+await db
+  .insertInto("person")
+  .values({ first_name: "Jennifer", gender: "female" })
+  .returning("id")
+  .executeTakeFirstOrThrow()
+```
+
+Node.js:
+
+```typescript
+import { GeneratedAlways, Kysely } from "kysely"
+import { NeonDialect } from "kysely-neon"
+import ws from "ws"
+
+interface Database {
+  person: PersonTable
+}
+
+interface PersonTable {
+  id: GeneratedAlways<number>
+  first_name: string
+  gender: "male" | "female" | "other"
+}
+
+const db = new Kysely<Database>({
+  dialent: new NeonDialect({
+    connectionString: process.env.DATABASE_URL,
+    webSocketConstructor: ws,
   }),
 })
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Kysely](https://github.com/koskimas/kysely) adapter for [Neon](https://neon.tech/) serverless postgres.
 
 ```bash
-npm i kysely-neon
+npm i kysely-neon @neondatabase/serverless ws
 ```
 
 > Created with help from [kysely-d1](https://github.com/aidenwallis/kysely-d1) and the [neon serverless binding](https://github.com/neondatabase/serverless)

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  files: ["src/tests/**/*.test.ts"],
+  files: ["tests/**/*.test.ts"],
   extensions: ["ts"],
   require: ["esbuild-register"],
   ignoredByWatcher: [".next", ".nsm"],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "tsup src/index.ts --dts"
+    "build": "tsup src/index.ts --dts",
+    "test": "ava"
   },
   "keywords": [],
   "author": "",
@@ -19,9 +20,10 @@
     "prettier": "^2.8.4",
     "tsup": "^6.6.3",
     "typescript": "^4.9.5",
-    "ws": "^8.12.1"
+    "ws": "^8.13.0"
   },
   "peerDependencies": {
-    "@neondatabase/serverless": "^0.2.6"
+    "@neondatabase/serverless": "^0.2.6",
+    "ws": "^8.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@neondatabase/serverless": "^0.2.6",
+    "@neondatabase/serverless": "^0.4.3",
     "@types/node": "^18.14.6",
     "ava": "^5.2.0",
     "esbuild": "^0.17.11",
@@ -23,7 +23,12 @@
     "ws": "^8.13.0"
   },
   "peerDependencies": {
-    "@neondatabase/serverless": "^0.2.6",
+    "@neondatabase/serverless": "^0.4.3",
     "ws": "^8.13.0"
+  },
+  "peerDependenciesMeta": {
+    "ws": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@neondatabase/serverless': ^0.2.6
+  '@neondatabase/serverless': ^0.4.3
   '@types/node': ^18.14.6
   ava: ^5.2.0
   esbuild: ^0.17.11
@@ -13,7 +13,7 @@ specifiers:
   ws: ^8.13.0
 
 devDependencies:
-  '@neondatabase/serverless': 0.2.6
+  '@neondatabase/serverless': 0.4.3
   '@types/node': 18.14.6
   ava: 5.2.0
   esbuild: 0.17.11
@@ -224,8 +224,10 @@ packages:
     dev: true
     optional: true
 
-  /@neondatabase/serverless/0.2.6:
-    resolution: {integrity: sha512-ogdFzxZAowsFZrjLEB0RqczKulD2A3A2k/9M1wGhmRUhXxuIS53WcEYGme2OLR7V+bAQ67s0K0DNkT7AYhFrgA==}
+  /@neondatabase/serverless/0.4.3:
+    resolution: {integrity: sha512-U8tpuF5f0R5WRsciR7iaJ5S2h54DWa6Z6CEW+J4KgwyvRN3q3qDz0MibdfFXU0WqnRoi/9RSf/2XN4TfeaOCbQ==}
+    dependencies:
+      '@types/pg': 8.6.6
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -251,6 +253,14 @@ packages:
 
   /@types/node/18.14.6:
     resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
+    dev: true
+
+  /@types/pg/8.6.6:
+    resolution: {integrity: sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==}
+    dependencies:
+      '@types/node': 18.14.6
+      pg-protocol: 1.6.0
+      pg-types: 2.2.0
     dev: true
 
   /acorn-walk/8.2.0:
@@ -1175,6 +1185,26 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pg-int8/1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
+  /pg-protocol/1.6.0:
+    resolution: {integrity: sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==}
+    dev: true
+
+  /pg-types/2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    dev: true
+
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -1214,6 +1244,28 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
+    dev: true
+
+  /postgres-array/2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /postgres-bytea/1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postgres-date/1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postgres-interval/1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      xtend: 4.0.2
     dev: true
 
   /prettier/2.8.4:
@@ -1564,6 +1616,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
+
+  /xtend/4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
     dev: true
 
   /y18n/5.0.8:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   prettier: ^2.8.4
   tsup: ^6.6.3
   typescript: ^4.9.5
-  ws: ^8.12.1
+  ws: ^8.13.0
 
 devDependencies:
   '@neondatabase/serverless': 0.2.6
@@ -22,7 +22,7 @@ devDependencies:
   prettier: 2.8.4
   tsup: 6.6.3_typescript@4.9.5
   typescript: 4.9.5
-  ws: 8.12.1
+  ws: 8.13.0
 
 packages:
 
@@ -1553,8 +1553,8 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /ws/8.12.1:
-    resolution: {integrity: sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==}
+  /ws/8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,9 @@ import {
   QueryCompiler,
   QueryResult,
 } from "kysely"
-import { Client } from "@neondatabase/serverless"
+import { Client, ClientConfig, NeonConfig } from "@neondatabase/serverless"
 
-interface NeonDialectConfig {
-  connectionString: string
-}
+type NeonDialectConfig = ClientConfig & Partial<NeonConfig>
 
 export class NeonDialect implements Dialect {
   config: NeonDialectConfig
@@ -79,9 +77,12 @@ class NeonConnection implements DatabaseConnection {
 
   constructor(config: NeonDialectConfig) {
     this.config = config
-    this.client = new Client({
-      connectionString: this.config.connectionString,
-    })
+
+    this.client = new Client(config)
+    Object.assign(
+      (this.client as unknown as { neonConfig: NeonConfig }).neonConfig,
+      config
+    )
   }
 
   async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {


### PR DESCRIPTION
Closes #1.
Closes https://github.com/kysely-org/kysely/issues/407.

Consumers are getting runtime errors telling them to install `ws`.

- bump `@neondatabase/serverless`.
- make `ws` optional peer dependency.
- extend dialect config to allow all neon client options AND neon config options (e.g. for passing ws in node.js).
- fix test.